### PR TITLE
Improve cross-platform path handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -283,7 +283,9 @@ class MainFrame(wx.Frame):
 			self.objCtrl.reload(True)
 			self.objCtrl.LoadStatus()
 			self.pathname = pathname
-			self.SetTitle(("%s (%s)" % (version_name,  self.pathname.split("\\")[-1].split(".")[0])) )
+                        import os
+                        file_base = os.path.splitext(os.path.basename(self.pathname))[0]
+                        self.SetTitle(("%s (%s)" % (version_name, file_base)))
 			self.ResetHistory()
 
 	def OnNew(self, event):
@@ -465,7 +467,9 @@ class MainFrame(wx.Frame):
 		except IOError:
 			wx.LogError("Cannot save current data in file %s" % pathname)
 		self.pathname = pathname
-		self.SetTitle(("%s (%s)" % (version_name,  self.pathname.split("\\")[-1].split(".")[0])))
+                import os
+                file_base = os.path.splitext(os.path.basename(self.pathname))[0]
+                self.SetTitle(("%s (%s)" % (version_name, file_base)))
 		self.savedIndex = self.historyIndex
 
 	def OnClose(self, event):

--- a/render_ctrl.py
+++ b/render_ctrl.py
@@ -200,9 +200,10 @@ class RenderCtrl(wx.Panel):
 			if fileDialog.ShowModal() == wx.ID_CANCEL:
 				return
 
-			pathname = fileDialog.GetPath()
-			self.data["Video Name"] = pathname
-			self.data["Render Dir"] = pathname.rsplit("\\",1)[0]
+                        pathname = fileDialog.GetPath()
+                        self.data["Video Name"] = pathname
+                        import os
+                        self.data["Render Dir"] = os.path.dirname(pathname)
 
 	def create_menus(self):
 		#builds the render menu

--- a/render_video_dialog.py
+++ b/render_video_dialog.py
@@ -128,8 +128,18 @@ class RenderVideoDialog(wx.Dialog):
 
 			print("getting image")
 			imgdata = self.canvas.GetImgData([self.xoffset, self.yoffset])
-			fin_surf = pygame.image.fromstring(imgdata, (self.canvas.resolution[0], self.canvas.resolution[1]), "RGBA", True)
-			pygame.image.save(fin_surf, self.data["Render Dir"] + "\\Frames\\{0:06}.png".format(self.data["Current Frame"]))
+                        fin_surf = pygame.image.fromstring(
+                            imgdata,
+                            (self.canvas.resolution[0], self.canvas.resolution[1]),
+                            "RGBA",
+                            True,
+                        )
+                        frame_path = os.path.join(
+                            self.data["Render Dir"],
+                            "Frames",
+                            "{0:06}.png".format(self.data["Current Frame"]),
+                        )
+                        pygame.image.save(fin_surf, frame_path)
 			print("turning off frame buffer")
 			
 			self.data["Current Frame"] += 1
@@ -154,10 +164,11 @@ class RenderVideoDialog(wx.Dialog):
 		self.window.rendering = True
 		self.data["Current Frame"] = 0
 		print("setting directory")
-		if os.path.isdir( self.data["Render Dir"] + "\\Frames"):
-			shutil.rmtree( self.data["Render Dir"] + "\\Frames")
-		print("making directory")
-		os.mkdir( self.data["Render Dir"] + "\\Frames")
+                frames_dir = os.path.join(self.data["Render Dir"], "Frames")
+                if os.path.isdir(frames_dir):
+                        shutil.rmtree(frames_dir)
+                print("making directory")
+                os.mkdir(frames_dir)
 		print("setting label")
 		self.frames_render_status.SetLabel("Rendering...")
 		self.canvas.FrameBufferOn()
@@ -177,8 +188,11 @@ class RenderVideoDialog(wx.Dialog):
 			os.remove(self.data["Video Name"])
 		if self.video_add_audio_box.GetValue():
 			(
-				ffmpeg
-				.input(self.data["Render Dir"] + "/Frames/%06d.png", framerate=self.data["FPS"])
+                                ffmpeg
+                                .input(
+                                    os.path.join(self.data["Render Dir"], "Frames", "%06d.png"),
+                                    framerate=self.data["FPS"],
+                                )
 				.output(self.data["Video Name"])
 				.global_args("-i", self.data["Audio"], 
 					"-f", "image2",
@@ -192,8 +206,11 @@ class RenderVideoDialog(wx.Dialog):
 
 		else:
 			(
-				ffmpeg
-				.input(self.data["Render Dir"] + "/Frames/%06d.png", framerate=self.data["FPS"])
+                                ffmpeg
+                                .input(
+                                    os.path.join(self.data["Render Dir"], "Frames", "%06d.png"),
+                                    framerate=self.data["FPS"],
+                                )
 				.output(self.data["Video Name"])
 				.global_args(
 					"-f", "image2",

--- a/timeline_ctrl.py
+++ b/timeline_ctrl.py
@@ -6,6 +6,7 @@ import pygame
 
 #other built in libraries
 import copy
+import os
 from datetime import datetime
 
 #pygame rendering panel, designed to layout
@@ -214,8 +215,9 @@ class TimelineCtrl(wx.Panel):
 			self.data["Audio"] = pathname
 			self.wavedata.gen_wavedata(self.data["Audio"])
 			self.gen_waveform()
-			self.loaded = True
-			self.window.Set_Forth_Status(pathname.split("\\")[-1])
+                        self.loaded = True
+                        import os
+                        self.window.Set_Forth_Status(os.path.basename(pathname))
 		#except:
 		#	pass
 


### PR DESCRIPTION
## Summary
- replace Windows-style path joins with `os.path.join`
- use `os.path.basename` to display filenames
- derive render directory with `os.path.dirname`
- update timeline controller with cross-platform audio status

## Testing
- `python -m pip install -r requirements.txt` *(fails: building wheel for wxPython)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686535a7f910832bafc00e39f39f775f