### PR TITLE
Simplify dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 wxPython
 pygame
 PyOpenGL
-ffmpeg-python
-numpy
-scipy

--- a/sampler.py
+++ b/sampler.py
@@ -1,5 +1,6 @@
 import sys
-import scipy.io.wavfile as wav
+import wave
+import struct
 
 #loads wav file as array of ints which can be normalized and turned into a visual waveform
 #to be restructured later into an object/class for faster resize times
@@ -15,11 +16,27 @@ class wavedata:
 		self.to_mono()
 
 	def to_mono(self, channel=0):
-		(freq, sig) = wav.read(self.filename)
-		if sig.ndim == 2:
-			self.wavedata = list(sig[:,channel])
+		with wave.open(self.filename, 'rb') as wf:
+			n_channels = wf.getnchannels()
+			n_frames = wf.getnframes()
+			sampwidth = wf.getsampwidth()
+			frames = wf.readframes(n_frames)
+
+		if sampwidth == 1:
+			fmt = "<%dB" % (n_frames * n_channels)
+		elif sampwidth == 2:
+			fmt = "<%dh" % (n_frames * n_channels)
+		elif sampwidth == 4:
+			fmt = "<%di" % (n_frames * n_channels)
 		else:
-			self.wavedata = list(sig)
+			raise ValueError("Unsupported sample width: %d" % sampwidth)
+
+		data = struct.unpack(fmt, frames)
+
+		if n_channels > 1:
+			self.wavedata = list(data[channel::n_channels])
+		else:
+			self.wavedata = list(data)
 
 	def Normalize(self, lst, height):
 		return [int(i/max(lst)*height) for i in lst]


### PR DESCRIPTION
## Summary
- use the built-in `wave` module instead of SciPy for reading audio in `sampler.py`
- drop unused deps from `requirements.txt`
- call ffmpeg using `subprocess` rather than `ffmpeg-python`

## Testing
- `python -m py_compile sampler.py render_video_dialog.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686552ed2ecc832b826dd00c87c04d98